### PR TITLE
feat: rework Docker image with updated Node, Bun, and added Terraform support CLD-534

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,15 @@
 ARG BASE_IMAGE=alpine:3.21
+ARG NODE_VERSION=20.19.1
+ARG TERRAFORM_VERSION=1.11.4
+ARG BUN_VERSION=1.2.11 
+## bun version
+
+ARG BUN_RUNTIME_TRANSPILER_CACHE_PATH=0    
+# Ensure `bun install -g` works    
+ARG BUN_INSTALL_BIN=/usr/local/bin    
 
 # hadolint ignore=DL3006
-FROM ${BASE_IMAGE} AS common
+FROM ${BASE_IMAGE} AS common 
 
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 
@@ -13,7 +21,6 @@ RUN apk --no-cache add \
 FROM common AS base
 
 ARG TARGETARCH
-
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 
 RUN echo "hosts: files dns" > /etc/nsswitch.conf \
@@ -32,7 +39,6 @@ RUN apk -U upgrade && apk add --no-cache \
     openssh-keygen \
     tzdata \
     bash \
-    nodejs \
     npm \
     yarn \
     python3
@@ -59,92 +65,23 @@ RUN REGULA_LATEST_VERSION=$(curl -s https://api.github.com/repos/fugue/regula/re
     chmod 755 /usr/local/bin/regula && \
     rm /tmp/regula.tar.gz
 
-# From https://github.com/oven-sh/bun/blob/main/dockerhub/alpine/Dockerfile
-FROM common AS bun
+FROM oven/bun:${BUN_VERSION}-alpine AS bun
 
-ARG BUN_VERSION=latest
-ARG GLIBC_VERSION=2.34-r0
-ARG GLIBC_VERSION_AARCH64=2.26-r1
+# Disable the runtime transpiler cache by default inside Docker containers.
+# On ephemeral containers, the cache is not useful
+ARG BUN_RUNTIME_TRANSPILER_CACHE_PATH=0
+ENV BUN_RUNTIME_TRANSPILER_CACHE_PATH=${BUN_RUNTIME_TRANSPILER_CACHE_PATH}
 
-SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
+# Ensure `bun install -g` works
+ARG BUN_INSTALL_BIN=/usr/local/bin
+ENV BUN_INSTALL_BIN=${BUN_INSTALL_BIN}
 
-# hadolint ignore=DL3018,DL3003,SC2043
-RUN apk --no-cache add \
-      dirmngr \
-      gpg \
-      gpg-agent \
-      unzip \
-    && arch="$(apk --print-arch)" \
-    && case "${arch##*-}" in \
-      x86_64) build="x64-baseline";; \
-      aarch64) build="aarch64";; \
-      *) echo "error: unsupported architecture: $arch"; exit 1 ;; \
-    esac \
-    && version="$BUN_VERSION" \
-    && case "$version" in \
-      latest | canary | bun-v*) tag="$version"; ;; \
-      v*)                       tag="bun-$version"; ;; \
-      *)                        tag="bun-v$version"; ;; \
-    esac \
-    && case "$tag" in \
-      latest) release="latest/download"; ;; \
-      *)      release="download/$tag"; ;; \
-    esac \
-    && curl "https://github.com/oven-sh/bun/releases/$release/bun-linux-$build.zip" \
-      -fsSLO \
-      --compressed \
-      --retry 5 \
-      || (echo "error: failed to download: $tag" && exit 1) \
-    && for key in \
-      "F3DCC08A8572C0749B3E18888EAB4D40A7B22B59" \
-    ; do \
-      gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys "$key" \
-      || gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" ; \
-    done \
-    && curl "https://github.com/oven-sh/bun/releases/$release/SHASUMS256.txt.asc" \
-      -fsSLO \
-      --compressed \
-      --retry 5 \
-    && gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc \
-      || (echo "error: failed to verify: $tag" && exit 1) \
-    && grep " bun-linux-$build.zip\$" SHASUMS256.txt | sha256sum -c - \
-      || (echo "error: failed to verify: $tag" && exit 1) \
-    && unzip "bun-linux-$build.zip" \
-    && mv "bun-linux-$build/bun" /usr/local/bin/bun \
-    && rm -f "bun-linux-$build.zip" SHASUMS256.txt.asc SHASUMS256.txt \
-    && chmod +x /usr/local/bin/bun \
-    && cd /tmp \
-    && case "${arch##*-}" in \
-      x86_64) curl "https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}/glibc-${GLIBC_VERSION}.apk" \
-        -fsSLO \
-        --compressed \
-        --retry 5 \
-        || (echo "error: failed to download: glibc v${GLIBC_VERSION}" && exit 1) \
-      && mv "glibc-${GLIBC_VERSION}.apk" glibc.apk \
-      && curl "https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}/glibc-bin-${GLIBC_VERSION}.apk" \
-        -fsSLO \
-        --compressed \
-        --retry 5 \
-        || (echo "error: failed to download: glibc-bin v${GLIBC_VERSION}" && exit 1) \
-      && mv "glibc-bin-${GLIBC_VERSION}.apk" glibc-bin.apk ;; \
-      aarch64) curl "https://raw.githubusercontent.com/squishyu/alpine-pkg-glibc-aarch64-bin/master/glibc-${GLIBC_VERSION_AARCH64}.apk" \
-        -fsSLO \
-        --compressed \
-        --retry 5 \
-        || (echo "error: failed to download: glibc v${GLIBC_VERSION_AARCH64}" && exit 1) \
-      && mv "glibc-${GLIBC_VERSION_AARCH64}.apk" glibc.apk \
-      && curl "https://raw.githubusercontent.com/squishyu/alpine-pkg-glibc-aarch64-bin/master/glibc-bin-${GLIBC_VERSION_AARCH64}.apk" \
-        -fsSLO \
-        --compressed \
-        --retry 5 \
-        || (echo "error: failed to download: glibc-bin v${GLIBC_VERSION_AARCH64}" && exit 1) \
-      && mv "glibc-bin-${GLIBC_VERSION_AARCH64}.apk" glibc-bin.apk ;; \
-      *) echo "error: unsupported architecture '$arch'"; exit 1 ;; \
-    esac
-
+FROM node:${NODE_VERSION}-alpine AS node
 
 # hadolint ignore=DL3007
 FROM ghcr.io/spacelift-io/aws-cli-alpine:latest AS aws-cli
+
+FROM hashicorp/terraform:${TERRAFORM_VERSION} AS terraform-latest
 
 FROM base
 
@@ -152,14 +89,18 @@ FROM base
 COPY --from=aws-cli /usr/local/aws-cli/ /usr/local/aws-cli/
 COPY --from=aws-cli /aws-cli-bin/ /usr/local/bin/
 
+# Copy node binaries
+COPY --from=node /usr/local/bin/node /usr/local/bin/node
+COPY --from=node /usr/local/bin/npm /usr/local/bin/npm
+COPY --from=node /usr/local/lib/node_modules /usr/local/lib/node_modules
+
+# Copy the latest terraform version into the base layer
+COPY --from=terraform-latest /bin/terraform /usr/local/bin/
+
 # Copy Bun binary
 COPY --from=bun /usr/local/bin/bun /usr/local/bin/
 
-RUN --mount=type=bind,from=bun,source=/tmp,target=/tmp \
-      apk --no-cache --force-overwrite --allow-untrusted add \
-      /tmp/glibc.apk \
-      /tmp/glibc-bin.apk \
-    && ln -s /usr/local/bin/bun /usr/local/bin/bunx
+RUN ln -s /usr/local/bin/bun /usr/local/bin/bunx
 
 # Check versions
 RUN echo "Software installed:"; \
@@ -168,6 +109,8 @@ RUN echo "Software installed:"; \
     infracost --version; \
     echo "Prettier v$(prettier --version)"; \
     echo "Regula $(regula version)"; \
-    echo "Bun v$(bun --version)"
+    echo "Bun v$(bun --version)"; \
+    terraform --version; \
+    node -v;
 
 USER spacelift

--- a/Dockerfile
+++ b/Dockerfile
@@ -98,6 +98,8 @@ COPY --from=bun /usr/local/bin/bun /usr/local/bin/
 
 RUN ln -s /usr/local/bin/bun /usr/local/bin/bunx
 
+SHELL ["/bin/ash", "-o", "pipefail", "-c"]
+
 # Check versions
 RUN echo "Software installed:"; \
     aws --version; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,6 @@ ARG NODE_VERSION=20.19.1
 ARG TERRAFORM_VERSION=1.11.4
 ARG BUN_VERSION=1.2.11 
 
-ARG BUN_RUNTIME_TRANSPILER_CACHE_PATH=0    
-# Ensure `bun install -g` works    
-ARG BUN_INSTALL_BIN=/usr/local/bin    
-
 # hadolint ignore=DL3006
 FROM ${BASE_IMAGE} AS common
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,16 @@
 
 This repo contains the Dockerfile for building our Spacelift CDKTF AWS runner image, which contains all the necessary tools for our Spacelift pipeline.
 
+The runner image builds the following tools for the different spacelift runners to use:
+* Terraform 
+* Bun
+* Node
+* AWS CLI
+* Infracost
+* Regula
+
+We build these tools ourselves to override the default behaviour of the spacelift runners and to accomodate the use of CDKTF instead of regular terraform. 
+
 ## Docker Repository
 
 The image is pushed to the `ghcr.io/stabl-energy/spacelift-runner-cdktf` public repository.
@@ -19,3 +29,11 @@ $ git push origin v1.1.0
 ```
 
 We also have a weekly cron job that re-runs the `main` branch just to have the latest package updates.
+
+From there we use this latest image to build seperate image for the different components of our infrastrucutre, which are:
+* [SBC infrastructure](https://github.com/Stabl-Energy/SBC-Infrastructure/blob/test/Dockerfile)
+* [Grafana infrastructure](https://github.com/Stabl-Energy/Grafana-Infrastructure/blob/test/Dockerfile)
+* [External infrastructure](https://github.com/Stabl-Energy/External-Infrastructure/blob/main/Dockerfile)
+* [Management infrastructure](https://github.com/Stabl-Energy/Management-Infrastructure/blob/main/Dockerfile)
+* [Spacelift infrastructure](https://github.com/Stabl-Energy/Spacelift-Infrastructure/blob/main/Dockerfile)
+


### PR DESCRIPTION
This PR updates our custom spacelift runner image by updating node version, updating bun installation, and adding Terraform for custom runner behaviour.
Ticket: https://linear.app/stabl/issue/CLD-534/spacelift-using-newer-terraform-version

## ⚠️ Important Notes
The changes in this PR affects the following repos:
https://github.com/Stabl-Energy/Grafana-Infrastructure/blob/test/Dockerfile
https://github.com/Stabl-Energy/Management-Infrastructure/blob/main/Dockerfile
https://github.com/Stabl-Energy/Spacelift-Infrastructure/blob/main/Dockerfile
https://github.com/Stabl-Energy/External-Infrastructure/blob/main/Dockerfile
https://github.com/Stabl-Energy/SBC-Infrastructure/blob/test/Dockerfile

Additionally, this PR works hand I hand with that PR https://github.com/Stabl-Energy/Spacelift-Infrastructure/pull/184#pullrequestreview-2805931495